### PR TITLE
Layout builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ options to block configuration by creating a custom plugin. It is advisable to
 do this primarily in themes since the majority of styles should be specific to a
 theme.
 
+The new core Layout Builder is supported and will offer a new contextual link for
+"Style settings". This way your styles will work for blocks regardless as to
+whether you place them via the new Layout Builder or the traditional Blocks UI.
+
 **Tutorial Video:** [https://youtu.be/Y0t8owlV2_4](https://youtu.be/Y0t8owlV2_4) 
 
 ### Dependencies
@@ -37,6 +41,12 @@ nested.
 
 By adding a `template` you may specify a template theme suggestion of your
 choosing for the block.
+
+By default, each field value will be set as a CSS class on the block. The one
+exception will be checkboxes. The checkbox data is passed along (with other
+style data) to the theme layer and can be accessed in a preprocess function at
+`$variables['configuration']['block_styles']` or in a Twig template at
+`{{ configuration.block_styles }}`
 
 ### Example Plugins
 
@@ -71,12 +81,9 @@ proper plugin Annotations such as:
  */
 ```
 
-Override the `BlockStyleBase::buildConfigurationForm` method to extend the `$form` array
-with your own custom style options using the
+Override the `BlockStyleBase::buildConfigurationForm` method to extend the
+`$form` array with your own custom style options using the
 [Form API](https://api.drupal.org/api/drupal/elements).
-
-A `block_styles` fieldset is automatically provided that can be used to do some
-automatic loading of values as classes onto the block attributes.
 
 ```
 $styles = $this->getConfiguration();
@@ -134,20 +141,26 @@ sample_block_style:
     - 'block_plugin_id'
 ```
 
+### Match all derivatives of a base plugin id
+
+You can also match any derivatives of a base plugin id by adding `:*` such as
+`system_menu_block:*` which will match all derivatives of the menu blocks such
+as `system_menu_block:main`.
+
 ### How to discover a 'block plugin id'
 
 It might be frustrating at first trying to figure out how to get a block's
 plugin id. In a theme's `themename.theme` file just preprocess a block. One of
-the variables available is the `base_plugin_id`.
+the variables available is the `plugin_id`.
 
 ```php
 /**
  * Implements hook_preprocess_block().
  */
 function themename_preprocess_block(array &$variables) {
-  // Get the base plugin id
-  $base_plugin_id = $variables['base_plugin_id'];
-  print '<pre>' . $base_plugin_id . '</pre>';
+  // Get the plugin id.
+  $plugin_id = $variables['plugin_id'];
+  print '<pre>' . $plugin_id . '</pre>';
 }
 ```
 

--- a/block_style_plugins.libraries.yml
+++ b/block_style_plugins.libraries.yml
@@ -1,0 +1,5 @@
+off_canvas:
+  version: 1.x
+  css:
+    component:
+      css/off-canvas.css: {}

--- a/block_style_plugins.links.contextual.yml
+++ b/block_style_plugins.links.contextual.yml
@@ -1,0 +1,9 @@
+block_style_plugins.layout_builder.styles:
+  title: 'Style settings'
+  route_name: 'block_style_plugins.layout_builder.styles'
+  group: 'layout_builder_block'
+  options:
+    attributes:
+      class: ['use-ajax']
+      data-dialog-type: dialog
+      data-dialog-renderer: off_canvas

--- a/block_style_plugins.module
+++ b/block_style_plugins.module
@@ -46,6 +46,11 @@ function block_style_plugins_form_block_form_alter(&$form, FormStateInterface $f
  * Implements hook_preprocess_block().
  */
 function block_style_plugins_preprocess_block(&$variables) {
+  // Exit if this is a layout builder block since everything is already set.
+  if (empty($variables['elements']['#id'])) {
+    return $variables;
+  }
+
   // Retrieve a list of style plugin definitions.
   /** @var Drupal\block_style_plugins\Plugin\BlockStyleManager $plugin_manager */
   $plugin_manager = \Drupal::service('plugin.manager.block_style.processor');

--- a/block_style_plugins.routing.yml
+++ b/block_style_plugins.routing.yml
@@ -3,6 +3,7 @@ block_style_plugins.layout_builder.styles:
   defaults:
     _form: '\Drupal\block_style_plugins\Form\BlockStyleForm'
   requirements:
+    _module_dependencies: 'layout_builder'
     _permission: 'configure any layout'
   options:
     _admin_route: TRUE
@@ -15,6 +16,7 @@ block_style_plugins.layout_builder.add_styles:
   defaults:
     _form: '\Drupal\block_style_plugins\Form\ConfigureStyles'
   requirements:
+    _module_dependencies: 'layout_builder'
     _permission: 'configure any layout'
   options:
     _admin_route: TRUE
@@ -27,6 +29,7 @@ block_style_plugins.layout_builder.delete_styles:
   defaults:
     _form: '\Drupal\block_style_plugins\Form\DeleteStyles'
   requirements:
+    _module_dependencies: 'layout_builder'
     _permission: 'configure any layout'
   options:
     _admin_route: TRUE

--- a/block_style_plugins.routing.yml
+++ b/block_style_plugins.routing.yml
@@ -1,0 +1,35 @@
+block_style_plugins.layout_builder.styles:
+  path: '/block_style_plugins/styles/block/{section_storage_type}/{section_storage}/{delta}/{uuid}'
+  defaults:
+    _form: '\Drupal\block_style_plugins\Form\BlockStyleForm'
+  requirements:
+    _permission: 'configure any layout'
+  options:
+    _admin_route: TRUE
+    parameters:
+      section_storage:
+        layout_builder_tempstore: TRUE
+
+block_style_plugins.layout_builder.add_styles:
+  path: '/block_style_plugins/styles/block/{section_storage_type}/{section_storage}/{delta}/{uuid}/{plugin_id}'
+  defaults:
+    _form: '\Drupal\block_style_plugins\Form\ConfigureStyles'
+  requirements:
+    _permission: 'configure any layout'
+  options:
+    _admin_route: TRUE
+    parameters:
+      section_storage:
+        layout_builder_tempstore: TRUE
+
+block_style_plugins.layout_builder.delete_styles:
+  path: '/block_style_plugins/styles/block/{section_storage_type}/{section_storage}/{delta}/{uuid}/{plugin_id}/delete'
+  defaults:
+    _form: '\Drupal\block_style_plugins\Form\DeleteStyles'
+  requirements:
+    _permission: 'configure any layout'
+  options:
+    _admin_route: TRUE
+    parameters:
+      section_storage:
+        layout_builder_tempstore: TRUE

--- a/block_style_plugins.services.yml
+++ b/block_style_plugins.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\block_style_plugins\Plugin\BlockStyleManager
     parent: default_plugin_manager
     arguments: ['@theme_handler']
+  block_style_plugins.component_styles_subscriber:
+    class: Drupal\block_style_plugins\EventSubscriber\SectionComponentStyles
+    arguments: ['@plugin.manager.block_style.processor']
+    tags:
+      - { name: event_subscriber }

--- a/css/off-canvas.css
+++ b/css/off-canvas.css
@@ -1,0 +1,5 @@
+#drupal-off-canvas .operations {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1em;
+}

--- a/src/EventSubscriber/SectionComponentStyles.php
+++ b/src/EventSubscriber/SectionComponentStyles.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\block_style_plugins\EventSubscriber;
+
+use Drupal\block_style_plugins\Plugin\BlockStyleManager;
+use Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent;
+use Drupal\layout_builder\LayoutBuilderEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Adds Layout Builder component styles.
+ */
+class SectionComponentStyles implements EventSubscriberInterface {
+
+  /**
+   * The Block Styles Manager.
+   *
+   * @var \Drupal\layout_builder\Plugin\BlockStyles\BlockStylesManager
+   */
+  protected $blockStyleManager;
+
+  /**
+   * Creates a SectionComponentStyles object.
+   *
+   * @param \Drupal\block_style_plugins\Plugin\BlockStyleManager $blockStyleManager
+   *   The Block Style Manager.
+   */
+  public function __construct(BlockStyleManager $blockStyleManager) {
+    $this->blockStyleManager = $blockStyleManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = 'onBuildRender';
+    return $events;
+  }
+
+  /**
+   * Add styles to a section component.
+   *
+   * @param \Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent $event
+   *   The section component build render array event.
+   */
+  public function onBuildRender(SectionComponentBuildRenderArrayEvent $event) {
+    $block_styles = $event->getComponent()->get('block_styles');
+    $block_styles = $block_styles ? $block_styles : [];
+
+    if ($block_styles) {
+      $build = $event->getBuild();
+
+      // Add styles to the configuration array so that they can be accessed in a
+      // preprocess $variables['configuration']['block_styles'].
+      $build['#configuration']['block_styles'] = $block_styles;
+
+      // Look for all available plugins.
+      $available_plugins = $this->blockStyleManager->getDefinitions();
+
+      foreach ($block_styles as $plugin_id => $configuration) {
+        // Only instantiate plugins that are available.
+        if (array_key_exists($plugin_id, $available_plugins)) {
+          /** @var \Drupal\layout_builder\Plugin\BlockStyles\BlockStylesInterface $plugin */
+          $plugin = $this->blockStyleManager->createInstance($plugin_id, $configuration);
+          $build = $plugin->build($build);
+        }
+      }
+
+      $event->setBuild($build);
+    }
+  }
+
+}

--- a/src/EventSubscriber/SectionComponentStyles.php
+++ b/src/EventSubscriber/SectionComponentStyles.php
@@ -33,7 +33,13 @@ class SectionComponentStyles implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = 'onBuildRender';
+    $events = [];
+
+    // Skip this if the Layout Builder is not installed.
+    if (class_exists('\Drupal\layout_builder\LayoutBuilderEvents')) {
+      $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = 'onBuildRender';
+    }
+
     return $events;
   }
 

--- a/src/EventSubscriber/SectionComponentStyles.php
+++ b/src/EventSubscriber/SectionComponentStyles.php
@@ -50,10 +50,6 @@ class SectionComponentStyles implements EventSubscriberInterface {
     if ($block_styles) {
       $build = $event->getBuild();
 
-      // Add styles to the configuration array so that they can be accessed in a
-      // preprocess $variables['configuration']['block_styles'].
-      $build['#configuration']['block_styles'] = $block_styles;
-
       // Look for all available plugins.
       $available_plugins = $this->blockStyleManager->getDefinitions();
 

--- a/src/Form/BlockStyleForm.php
+++ b/src/Form/BlockStyleForm.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Drupal\block_style_plugins\Form;
+
+use Drupal\block_style_plugins\Plugin\BlockStyleManager;
+use Drupal\Core\Ajax\AjaxFormHelperTrait;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\OpenOffCanvasDialogCommand;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\layout_builder\SectionStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Provides a form for applying styles to a block.
+ *
+ * @internal
+ */
+class BlockStyleForm extends FormBase {
+
+  use AjaxFormHelperTrait;
+
+  /**
+   * The Block Styles Manager.
+   *
+   * @var \Drupal\block_style_plugins\Plugin\BlockStyleManager
+   */
+  protected $blockStyleManager;
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The section storage.
+   *
+   * @var \Drupal\layout_builder\SectionStorageInterface
+   */
+  protected $sectionStorage;
+
+  /**
+   * The layout section delta.
+   *
+   * @var int
+   */
+  protected $delta;
+
+  /**
+   * The uuid of the block component.
+   *
+   * @var string
+   */
+  protected $uuid;
+
+  /**
+   * Constructs a BlockStylesForm object.
+   *
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder.
+   * @param \Drupal\block_style_plugins\Plugin\BlockStyleManager $blockStyleManager
+   *   The Block Style Manager.
+   */
+  public function __construct(FormBuilderInterface $form_builder, BlockStyleManager $blockStyleManager) {
+    $this->formBuilder = $form_builder;
+    $this->blockStyleManager = $blockStyleManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('form_builder'),
+      $container->get('plugin.manager.block_style.processor')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'block_style_plugins_layout_builder_styles';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL, $delta = NULL, $uuid = NULL) {
+    $this->sectionStorage = $section_storage;
+    $this->delta = $delta;
+    $this->uuid = $uuid;
+
+    $block_styles = $section_storage->getSection($delta)->getComponent($uuid)->get('block_styles');
+
+    // Retrieve a list of style plugin definitions.
+    $style_plugins = [];
+    foreach ($this->blockStyleManager->getDefinitions() as $plugin_id => $definition) {
+      $style_plugins[$plugin_id] = $definition['label'];
+    }
+
+    // Create a list of applied styles with operation links.
+    $items = [];
+    foreach ($block_styles as $style_id => $configuration) {
+      $options = [
+        'attributes' => [
+          'class' => ['use-ajax'],
+          'data-dialog-type' => 'dialog',
+          'data-dialog-renderer' => 'off_canvas',
+          'data-outside-in-edit' => TRUE,
+        ],
+      ];
+
+      // Create links to edit and delete.
+      $links = [
+        'edit' => [
+          'title' => $this->t('Edit'),
+          'url' => Url::fromRoute('block_style_plugins.layout_builder.add_styles', $this->getParameters($style_id), $options),
+        ],
+        'delete' => [
+          'title' => $this->t('Delete'),
+          'url' => Url::fromRoute('block_style_plugins.layout_builder.delete_styles', $this->getParameters($style_id), $options),
+        ],
+      ];
+
+      // If there is no plugin for the set block style then we should only allow
+      // deleting. This could be due to a plugin being removed.
+      if (!isset($style_plugins[$style_id])) {
+        unset($links['edit']);
+      }
+
+      $plugin_label = !empty($style_plugins[$style_id]) ? $style_plugins[$style_id] : $this->t('Missing Style Plugin');
+
+      $items[] = [
+        ['#markup' => $plugin_label],
+        [
+          '#type' => 'operations',
+          '#links' => $links,
+        ],
+      ];
+    }
+    if ($items) {
+      $form['applied_styles_title'] = [
+        '#markup' => '<h3>' . $this->t('Applied Styles') . '</h3>',
+      ];
+      $form['applied_styles'] = [
+        '#prefix' => '<div id="applied-styles">',
+        '#suffix' => '</div>',
+        '#theme' => 'item_list',
+        '#items' => $items,
+        '#empty' => $this->t('No styles have been set.'),
+      ];
+    }
+
+    // Dropdown for adding styles.
+    $form['block_styles'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Add a style'),
+      '#options' => $style_plugins,
+      '#empty_value' => '',
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add Styles'),
+    ];
+    if ($this->isAjax()) {
+      $form['actions']['submit']['#ajax']['callback'] = '::ajaxSubmit';
+      $form['actions']['submit']['#ajax']['event'] = 'click';
+    }
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function successfulAjaxSubmit(array $form, FormStateInterface $form_state) {
+    $style_id = $form_state->getValue('block_styles');
+    $parameters = $this->getParameters($style_id);
+    $new_form = $this->formBuilder->getForm('\Drupal\block_style_plugins\Form\ConfigureStyles', $this->sectionStorage, $parameters['delta'], $parameters['uuid'], $parameters['plugin_id']);
+    $new_form['#action'] = (new Url('block_style_plugins.layout_builder.add_styles', $parameters))->toString();
+    $new_form['actions']['submit']['#attached']['drupalSettings']['ajax'][$new_form['actions']['submit']['#id']]['url'] = new Url('block_style_plugins.layout_builder.add_styles', $parameters, ['query' => [FormBuilderInterface::AJAX_FORM_REQUEST => TRUE]]);
+    $response = new AjaxResponse();
+    $response->addCommand(new OpenOffCanvasDialogCommand($this->t('Configure Styles'), $new_form));
+    return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $parameters = $this->getParameters($form_state->getValue('block_styles'));
+    $url = new Url('block_style_plugins.layout_builder.add_styles', $parameters);
+    $response = new RedirectResponse($url->toString());
+    $form_state->setResponse($response);
+  }
+
+  /**
+   * Gets the parameters needed for the various Url() and form invocations.
+   *
+   * @param string $style_id
+   *   The id of the style plugin.
+   *
+   * @return array
+   *   List of Url parameters.
+   */
+  protected function getParameters($style_id) {
+    return [
+      'section_storage_type' => $this->sectionStorage->getStorageType(),
+      'section_storage' => $this->sectionStorage->getStorageId(),
+      'delta' => $this->delta,
+      'uuid' => $this->uuid,
+      'plugin_id' => $style_id,
+    ];
+  }
+
+}

--- a/src/Form/BlockStyleForm.php
+++ b/src/Form/BlockStyleForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\block_style_plugins\Form;
 
 use Drupal\block_style_plugins\Plugin\BlockStyleManager;
+use Drupal\block_style_plugins\IncludeExcludeStyleTrait;
 use Drupal\Core\Ajax\AjaxFormHelperTrait;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\OpenOffCanvasDialogCommand;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class BlockStyleForm extends FormBase {
 
   use AjaxFormHelperTrait;
+  use IncludeExcludeStyleTrait;
 
   /**
    * The Block Styles Manager.
@@ -96,12 +98,17 @@ class BlockStyleForm extends FormBase {
     $this->delta = $delta;
     $this->uuid = $uuid;
 
-    $block_styles = $section_storage->getSection($delta)->getComponent($uuid)->get('block_styles');
+    $component = $block_styles = $section_storage->getSection($delta)->getComponent($uuid);
+    $block_styles = $component->get('block_styles');
 
     // Retrieve a list of style plugin definitions.
     $style_plugins = [];
     foreach ($this->blockStyleManager->getDefinitions() as $plugin_id => $definition) {
-      $style_plugins[$plugin_id] = $definition['label'];
+      // Check to see if this should only apply to includes or if it has been
+      // excluded.
+      if ($this->allowStyles($component->getPluginId(), $definition)) {
+        $style_plugins[$plugin_id] = $definition['label'];
+      }
     }
 
     // Create a list of applied styles with operation links.

--- a/src/Form/BlockStyleForm.php
+++ b/src/Form/BlockStyleForm.php
@@ -119,13 +119,16 @@ class BlockStyleForm extends FormBase {
       // Create links to edit and delete.
       $links = [
         'edit' => [
-          'title' => $this->t('Edit'),
-          'url' => Url::fromRoute('block_style_plugins.layout_builder.add_styles', $this->getParameters($style_id), $options),
+          '#title' => $this->t('Edit'),
+          '#type' => 'link',
+          '#url' => Url::fromRoute('block_style_plugins.layout_builder.add_styles', $this->getParameters($style_id), $options),
         ],
         'delete' => [
-          'title' => $this->t('Delete'),
-          'url' => Url::fromRoute('block_style_plugins.layout_builder.delete_styles', $this->getParameters($style_id), $options),
+          '#title' => $this->t('Delete'),
+          '#type' => 'link',
+          '#url' => Url::fromRoute('block_style_plugins.layout_builder.delete_styles', $this->getParameters($style_id), $options),
         ],
+        '#attributes' => ['class' => 'operations'],
       ];
 
       // If there is no plugin for the set block style then we should only allow
@@ -138,10 +141,7 @@ class BlockStyleForm extends FormBase {
 
       $items[] = [
         ['#markup' => $plugin_label],
-        [
-          '#type' => 'operations',
-          '#links' => $links,
-        ],
+        $links,
       ];
     }
     if ($items) {
@@ -154,6 +154,7 @@ class BlockStyleForm extends FormBase {
         '#theme' => 'item_list',
         '#items' => $items,
         '#empty' => $this->t('No styles have been set.'),
+        '#attached' => ['library' => ['block_style_plugins/off_canvas']]
       ];
     }
 

--- a/src/Form/ConfigureStyles.php
+++ b/src/Form/ConfigureStyles.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Drupal\block_style_plugins\Form;
+
+use Drupal\block_style_plugins\Plugin\BlockStyleInterface;
+use Drupal\block_style_plugins\Plugin\BlockStyleManager;
+use Drupal\Core\Ajax\AjaxFormHelperTrait;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\SubformState;
+use Drupal\Core\Plugin\PluginFormFactoryInterface;
+use Drupal\Core\Plugin\PluginWithFormsInterface;
+use Drupal\layout_builder\Controller\LayoutRebuildTrait;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a form to configure styles.
+ *
+ * @internal
+ */
+class ConfigureStyles extends FormBase {
+
+  use AjaxFormHelperTrait;
+  use LayoutRebuildTrait;
+
+  /**
+   * The Block Styles Manager.
+   *
+   * @var \Drupal\block_style_plugins\Plugin\BlockStyleManager
+   */
+  protected $blockStyleManager;
+
+  /**
+   * The layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface
+   */
+  protected $layoutTempstoreRepository;
+
+  /**
+   * The plugin form factory.
+   *
+   * @var \Drupal\Core\Plugin\PluginFormFactoryInterface
+   */
+  protected $pluginFormFactory;
+
+  /**
+   * The section storage.
+   *
+   * @var \Drupal\layout_builder\SectionStorageInterface
+   */
+  protected $sectionStorage;
+
+  /**
+   * The layout section delta.
+   *
+   * @var int
+   */
+  protected $delta;
+
+  /**
+   * The uuid of the block component.
+   *
+   * @var string
+   */
+  protected $uuid;
+
+  /**
+   * The block styles plugin being configured.
+   *
+   * @var \Drupal\block_style_plugins\Plugin\BlockStyleInterface
+   */
+  protected $blockStyles;
+
+  /**
+   * Constructs a ConfigureStyles object.
+   *
+   * @param \Drupal\layout_builder\LayoutTempstoreRepositoryInterface $layout_tempstore_repository
+   *   The layout tempstore repository.
+   * @param \Drupal\Core\Plugin\PluginFormFactoryInterface $plugin_form_manager
+   *   The plugin form manager.
+   * @param \Drupal\Core\DependencyInjection\ClassResolverInterface $class_resolver
+   *   The class resolver.
+   * @param \Drupal\block_style_plugins\Plugin\BlockStyleManager $blockStyleManager
+   *   The Block Style Manager.
+   */
+  public function __construct(LayoutTempstoreRepositoryInterface $layout_tempstore_repository, PluginFormFactoryInterface $plugin_form_manager, ClassResolverInterface $class_resolver, BlockStyleManager $blockStyleManager) {
+    $this->layoutTempstoreRepository = $layout_tempstore_repository;
+    $this->pluginFormFactory = $plugin_form_manager;
+    $this->classResolver = $class_resolver;
+    $this->blockStyleManager = $blockStyleManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('layout_builder.tempstore_repository'),
+      $container->get('plugin_form.factory'),
+      $container->get('class_resolver'),
+      $container->get('plugin.manager.block_style.processor')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'block_style_plugins_layout_builder_configure_styles';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL, $delta = NULL, $uuid = NULL, $plugin_id = NULL) {
+    $this->sectionStorage = $section_storage;
+    $this->delta = $delta;
+    $this->uuid = $uuid;
+
+    $block_styles = $section_storage->getSection($delta)->getComponent($uuid)->get('block_styles');
+    $stored_styles = !empty($block_styles[$plugin_id]) ? $block_styles[$plugin_id] : [];
+
+    $this->blockStyles = $this->blockStyleManager->createInstance($plugin_id);
+    $this->blockStyles->setConfiguration($stored_styles);
+
+    $form['#tree'] = TRUE;
+    $form['settings'] = [];
+    $subform_state = SubformState::createForSubform($form['settings'], $form, $form_state);
+    $form['settings'] = $this->getPluginForm($this->blockStyles)->buildConfigurationForm($form['settings'], $subform_state);
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $stored_styles ? $this->t('Update') : $this->t('Add Styles'),
+      '#button_type' => 'primary',
+    ];
+
+    if ($this->isAjax()) {
+      $form['actions']['submit']['#ajax']['callback'] = '::ajaxSubmit';
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $subform_state = SubformState::createForSubform($form['settings'], $form, $form_state);
+    $this->getPluginForm($this->blockStyles)->validateConfigurationForm($form['settings'], $subform_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $subform_state = SubformState::createForSubform($form['settings'], $form, $form_state);
+    $this->getPluginForm($this->blockStyles)->submitConfigurationForm($form, $subform_state);
+
+    $configuration = $configuration = $this->blockStyles->getConfiguration();
+    $plugin_id = $this->blockStyles->getPluginId();
+
+    $component = $this->sectionStorage->getSection($this->delta)->getComponent($this->uuid);
+    $block_styles = $component->get('block_styles');
+    $block_styles[$plugin_id] = $configuration;
+    $component->set('block_styles', $block_styles);
+
+    $this->layoutTempstoreRepository->set($this->sectionStorage);
+    $form_state->setRedirectUrl($this->sectionStorage->getLayoutBuilderUrl());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function successfulAjaxSubmit(array $form, FormStateInterface $form_state) {
+    return $this->rebuildAndClose($this->sectionStorage);
+  }
+
+  /**
+   * Retrieves the plugin form for a given block style.
+   *
+   * @param \Drupal\block_style_plugins\Plugin\BlockStyleInterface $blockStyles
+   *   The block styles plugin.
+   *
+   * @return \Drupal\Core\Plugin\PluginFormInterface
+   *   The plugin form for the condition.
+   */
+  protected function getPluginForm(BlockStyleInterface $blockStyles) {
+    if ($blockStyles instanceof PluginWithFormsInterface) {
+      return $this->pluginFormFactory->createInstance($blockStyles, 'configure');
+    }
+    return $blockStyles;
+  }
+
+}

--- a/src/Form/DeleteStyles.php
+++ b/src/Form/DeleteStyles.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Drupal\block_style_plugins\Form;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\OpenOffCanvasDialogCommand;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
+use Drupal\layout_builder\SectionStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a form to delete a block style.
+ *
+ * @internal
+ */
+class DeleteStyles extends ConfirmFormBase {
+
+  /**
+   * The layout tempstore repository.
+   *
+   * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface
+   */
+  protected $layoutTempstoreRepository;
+
+  /**
+   * The section storage.
+   *
+   * @var \Drupal\layout_builder\SectionStorageInterface
+   */
+  protected $sectionStorage;
+
+  /**
+   * The layout section delta.
+   *
+   * @var int
+   */
+  protected $delta;
+
+  /**
+   * The uuid of the block component.
+   *
+   * @var string
+   */
+  protected $uuid;
+
+
+  /**
+   * The plugin id of the style to be removed.
+   *
+   * @var string
+   */
+  protected $pluginId;
+
+  /**
+   * Constructs a DeleteStyles object.
+   *
+   * @param \Drupal\layout_builder\LayoutTempstoreRepositoryInterface $layout_tempstore_repository
+   *   The layout tempstore repository.
+   */
+  public function __construct(LayoutTempstoreRepositoryInterface $layout_tempstore_repository) {
+    $this->layoutTempstoreRepository = $layout_tempstore_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('layout_builder.tempstore_repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL, $delta = NULL, $uuid = NULL, $plugin_id = NULL) {
+    $this->sectionStorage = $section_storage;
+    $this->delta = $delta;
+    $this->uuid = $uuid;
+    $this->pluginId = $plugin_id;
+    $form = parent::buildForm($form, $form_state);
+    $form['actions']['cancel'] = $this->buildCancelLink();
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete this style?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    $parameters = $this->getParameters();
+    return new Url('block_style_plugins.layout_builder.styles', $parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'block_style_plugins_layout_builder_delete_styles';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $component = $this->sectionStorage->getSection($this->delta)->getComponent($this->uuid);
+    $block_styles = $component->get('block_styles');
+    unset($block_styles[$this->pluginId]);
+    $component->set('block_styles', $block_styles);
+
+    $this->layoutTempstoreRepository->set($this->sectionStorage);
+    $form_state->setRedirectUrl($this->sectionStorage->getLayoutBuilderUrl());
+  }
+
+  /**
+   * Build a cancel button for the confirm form.
+   */
+  protected function buildCancelLink() {
+    return [
+      '#type' => 'button',
+      '#value' => $this->getCancelText(),
+      '#ajax' => [
+        'callback' => '::ajaxCancel',
+      ],
+    ];
+  }
+
+  /**
+   * Provides an ajax callback for the cancel button.
+   */
+  public function ajaxCancel(array &$form, FormStateInterface $form_state) {
+    $parameters = $this->getParameters();
+    $new_form = \Drupal::formBuilder()->getForm('\Drupal\block_style_plugins\Form\BlockStyleForm', $this->sectionStorage, $parameters['delta'], $parameters['uuid']);
+    $new_form['#action'] = $this->getCancelUrl()->toString();
+    $response = new AjaxResponse();
+    $response->addCommand(new OpenOffCanvasDialogCommand($this->t('Configure Styles'), $new_form));
+    return $response;
+  }
+
+  /**
+   * Gets the parameters needed for the various Url() and form invocations.
+   *
+   * @return array
+   *   List of Url parameters.
+   */
+  protected function getParameters() {
+    return [
+      'section_storage_type' => $this->sectionStorage->getStorageType(),
+      'section_storage' => $this->sectionStorage->getStorageId(),
+      'delta' => $this->delta,
+      'uuid' => $this->uuid,
+    ];
+  }
+
+}

--- a/src/Form/DeleteStyles.php
+++ b/src/Form/DeleteStyles.php
@@ -5,6 +5,7 @@ namespace Drupal\block_style_plugins\Form;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\OpenOffCanvasDialogCommand;
 use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\layout_builder\LayoutTempstoreRepositoryInterface;
@@ -24,6 +25,13 @@ class DeleteStyles extends ConfirmFormBase {
    * @var \Drupal\layout_builder\LayoutTempstoreRepositoryInterface
    */
   protected $layoutTempstoreRepository;
+
+  /**
+   * The form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
 
   /**
    * The section storage.
@@ -57,10 +65,13 @@ class DeleteStyles extends ConfirmFormBase {
   /**
    * Constructs a DeleteStyles object.
    *
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The form builder.
    * @param \Drupal\layout_builder\LayoutTempstoreRepositoryInterface $layout_tempstore_repository
    *   The layout tempstore repository.
    */
-  public function __construct(LayoutTempstoreRepositoryInterface $layout_tempstore_repository) {
+  public function __construct(FormBuilderInterface $form_builder, LayoutTempstoreRepositoryInterface $layout_tempstore_repository) {
+    $this->formBuilder = $form_builder;
     $this->layoutTempstoreRepository = $layout_tempstore_repository;
   }
 
@@ -69,6 +80,7 @@ class DeleteStyles extends ConfirmFormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('form_builder'),
       $container->get('layout_builder.tempstore_repository')
     );
   }
@@ -139,7 +151,7 @@ class DeleteStyles extends ConfirmFormBase {
    */
   public function ajaxCancel(array &$form, FormStateInterface $form_state) {
     $parameters = $this->getParameters();
-    $new_form = \Drupal::formBuilder()->getForm('\Drupal\block_style_plugins\Form\BlockStyleForm', $this->sectionStorage, $parameters['delta'], $parameters['uuid']);
+    $new_form = $this->formBuilder->getForm('\Drupal\block_style_plugins\Form\BlockStyleForm', $this->sectionStorage, $parameters['delta'], $parameters['uuid']);
     $new_form['#action'] = $this->getCancelUrl()->toString();
     $response = new AjaxResponse();
     $response->addCommand(new OpenOffCanvasDialogCommand($this->t('Configure Styles'), $new_form));

--- a/src/IncludeExcludeStyleTrait.php
+++ b/src/IncludeExcludeStyleTrait.php
@@ -49,9 +49,10 @@ trait IncludeExcludeStyleTrait {
       $list = $plugin_definition['exclude'];
     }
 
-    if (!empty($list) && (in_array($plugin_id, $list))) {
+    if (!empty($list) && $this->matchPattern($plugin_id, $list)) {
       return TRUE;
     }
+
     return FALSE;
   }
 
@@ -77,7 +78,39 @@ trait IncludeExcludeStyleTrait {
       $list = $plugin_definition['include'];
     }
 
-    if (empty($list) || (in_array($plugin_id, $list))) {
+    if (empty($list) || $this->matchPattern($plugin_id, $list)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Match a plugin ID against a list of possible plugin IDs.
+   *
+   * @param string $plugin_id
+   *   The ID of the block being checked.
+   * @param array $plugin_list
+   *   List of plugin ids or plugin patterns of "plugin_id:*".
+   *
+   * @return bool
+   *   Return TRUE if the plugin ID matches a Plugin ID or pattern in the list.
+   */
+  protected function matchPattern($plugin_id, array $plugin_list) {
+    // First check to see if the id is already directly in the list.
+    if (in_array($plugin_id, $plugin_list)) {
+      return TRUE;
+    }
+
+    // Now check to see if this ID is a derivative on something in the list.
+    preg_match('/^([^:]+):?/', $plugin_id, $matches);
+    if ($matches && in_array($matches[1] . ':*', $plugin_list)) {
+      return TRUE;
+    }
+
+    // Match any inline blocks in Layout Builder.
+    preg_match('/^inline_block:(.+)/', $plugin_id, $matches);
+    if ($matches && in_array($matches[1], $plugin_list)) {
       return TRUE;
     }
 

--- a/src/IncludeExcludeStyleTrait.php
+++ b/src/IncludeExcludeStyleTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\block_style_plugins;
+
+/**
+ * Provides a helper for determining whether to include or exclude a plugin.
+ */
+trait IncludeExcludeStyleTrait {
+
+  /**
+   * Determine whether a style should be allowed.
+   *
+   * @param string $plugin_id
+   *   The ID of the block being checked.
+   * @param array $plugin_definition
+   *   A list of definitions for a block_style_plugin which could have 'include'
+   *   or 'exclude' as keys.
+   *
+   * @return bool
+   *   Return True if the block should show the styles.
+   */
+  public function allowStyles($plugin_id, array $plugin_definition) {
+    if ($this->includeOnly($plugin_id, $plugin_definition) && !$this->exclude($plugin_id, $plugin_definition)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Exclude styles from appearing on blocks.
+   *
+   * Determine if configuration should be excluded from certain blocks when a
+   * block plugin id or block content type is passed from a plugin.
+   *
+   * @param string $plugin_id
+   *   The ID of the block being checked.
+   * @param array $plugin_definition
+   *   A list of definitions for a block_style_plugins which could have the key
+   *   'exclude' set as a list of block plugin ids to disallow.
+   *
+   * @return bool
+   *   Return True if the current block should not get the styles.
+   */
+  public function exclude($plugin_id, array $plugin_definition) {
+    $list = [];
+
+    if (isset($plugin_definition['exclude'])) {
+      $list = $plugin_definition['exclude'];
+    }
+
+    if (!empty($list) && (in_array($plugin_id, $list))) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Only show styles on specific blocks.
+   *
+   * Determine if configuration should be only included on certain blocks when a
+   * block plugin id or block content type is passed from a plugin.
+   *
+   * @param string $plugin_id
+   *   The ID of the block being checked.
+   * @param array $plugin_definition
+   *   A list of definitions for a block_style_plugins which could have the key
+   *   'include' set as a list of block plugin ids to allow.
+   *
+   * @return bool
+   *   Return True if the current block should only get the styles.
+   */
+  public function includeOnly($plugin_id, array $plugin_definition) {
+    $list = [];
+
+    if (isset($plugin_definition['include'])) {
+      $list = $plugin_definition['include'];
+    }
+
+    if (empty($list) || (in_array($plugin_id, $list))) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/src/Plugin/BlockStyle.php
+++ b/src/Plugin/BlockStyle.php
@@ -50,14 +50,13 @@ class BlockStyle extends BlockStyleBase {
   public function themeSuggestion(array $suggestions, array $variables) {
     // Ensure that a template is set in the info file.
     if (isset($this->pluginDefinition['template'])) {
-      $plugin_id = $this->getPluginId();
       $template = $this->pluginDefinition['template'];
 
       $styles = $this->getStylesFromVariables($variables);
 
       // Only set suggestions if styles have been set for the block.
-      if ($styles && array_key_exists($plugin_id, $styles)) {
-        foreach ($styles[$plugin_id] as $style) {
+      if ($styles) {
+        foreach ($styles as $style) {
           if (!empty($style)) {
             $suggestions[] = $template;
             break;

--- a/src/Plugin/BlockStyle.php
+++ b/src/Plugin/BlockStyle.php
@@ -50,13 +50,14 @@ class BlockStyle extends BlockStyleBase {
   public function themeSuggestion(array $suggestions, array $variables) {
     // Ensure that a template is set in the info file.
     if (isset($this->pluginDefinition['template'])) {
+      $plugin_id = $this->getPluginId();
       $template = $this->pluginDefinition['template'];
 
       $styles = $this->getStylesFromVariables($variables);
 
       // Only set suggestions if styles have been set for the block.
-      if ($styles) {
-        foreach ($styles as $style) {
+      if ($styles && array_key_exists($plugin_id, $styles)) {
+        foreach ($styles[$plugin_id] as $style) {
           if (!empty($style)) {
             $suggestions[] = $template;
             break;

--- a/src/Plugin/BlockStyleBase.php
+++ b/src/Plugin/BlockStyleBase.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\block_style_plugins\Plugin;
 
+use Drupal\block_style_plugins\IncludeExcludeStyleTrait;
 use Drupal\Core\Form\SubformState;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -15,6 +16,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
  * Base class for Block style plugins.
  */
 abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface, ContainerFactoryPluginInterface {
+
+  use IncludeExcludeStyleTrait;
 
   /**
    * Plugin ID for the Block being configured.
@@ -125,9 +128,15 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
     $this->blockPlugin = $entity->getPlugin();
     $this->setBlockContentBundle();
 
+    // Find the plugin ID or block content bundle id.
+    $plugin_id = $this->blockPlugin->getPluginId();
+    if ($this->blockContentBundle) {
+      $plugin_id = $this->blockContentBundle;
+    }
+
     // Check to see if this should only apply to includes or if it has been
     // excluded.
-    if ($this->includeOnly() && !$this->exclude()) {
+    if ($this->allowStyles($plugin_id, $this->pluginDefinition)) {
 
       // Create a fieldset to contain style fields.
       if (!isset($form['block_styles'])) {
@@ -260,42 +269,6 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
    */
   public function calculateDependencies() {
     return [];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function exclude() {
-    $list = [];
-
-    if (isset($this->pluginDefinition['exclude'])) {
-      $list = $this->pluginDefinition['exclude'];
-    }
-
-    $block_plugin_id = $this->blockPlugin->getPluginId();
-
-    if (!empty($list) && (in_array($block_plugin_id, $list) || in_array($this->blockContentBundle, $list))) {
-      return TRUE;
-    }
-    return FALSE;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function includeOnly() {
-    $list = [];
-
-    if (isset($this->pluginDefinition['include'])) {
-      $list = $this->pluginDefinition['include'];
-    }
-
-    $block_plugin_id = $this->blockPlugin->getPluginId();
-
-    if (empty($list) || (in_array($block_plugin_id, $list) || in_array($this->blockContentBundle, $list))) {
-      return TRUE;
-    }
-    return FALSE;
   }
 
   /**

--- a/src/Plugin/BlockStyleBase.php
+++ b/src/Plugin/BlockStyleBase.php
@@ -213,11 +213,21 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
    * {@inheritdoc}
    */
   public function build(array $variables) {
+    // Is the Layout Builder being used?
+    $layout_builder = (empty($variables['elements']['#id'])) ? TRUE : FALSE;
+
     $styles = $this->getStylesFromVariables($variables);
 
     if ($styles) {
-      // Add all styles config to the $variables array.
-      $variables['block_styles'][$this->pluginId] = $styles;
+      // Add styles to the configuration array so that they can be accessed in a
+      // preprocess $variables['configuration']['block_styles'] or in a twig
+      // template as {{ configuration.block_styles.plugin_id.field_name }}.
+      if ($layout_builder) {
+        $variables['#configuration']['block_styles'][$this->pluginId] = $styles;
+      }
+      else {
+        $variables['configuration']['block_styles'][$this->pluginId] = $styles;
+      }
 
       // Add each style value as a class.
       foreach ($styles as $class) {
@@ -227,12 +237,12 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
         }
 
         // Ensure that we have a block id. If not, the Layout Builder is used.
-        if (!empty($variables['elements']['#id'])) {
-          $variables['attributes']['class'][] = $class;
-        }
-        else {
+        if ($layout_builder) {
           // Layout Builder needs a "#".
           $variables['#attributes']['class'][] = $class;
+        }
+        else {
+          $variables['attributes']['class'][] = $class;
         }
       }
     }
@@ -310,8 +320,8 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
 
       // Style config might not be set if this is happening in a hook so we will
       // check if a block_styles variable is set and get the config.
-      if (empty($styles) && isset($variables['elements']['block_styles'][$this->pluginId])) {
-        $this->setConfiguration($variables['elements']['block_styles'][$this->pluginId]);
+      if (empty($styles) && isset($variables['elements']['#configuration']['block_styles'][$this->pluginId])) {
+        $this->setConfiguration($variables['elements']['#configuration']['block_styles'][$this->pluginId]);
         $styles = $styles = $this->getConfiguration();
       }
     }

--- a/src/Plugin/BlockStyleBase.php
+++ b/src/Plugin/BlockStyleBase.php
@@ -337,8 +337,8 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
 
       // Style config might not be set if this is happening in a hook so we will
       // check if a block_styles variable is set and get the config.
-      if (empty($styles) && isset($variables['elements']['block_styles'])) {
-        $this->setConfiguration($variables['elements']['block_styles']);
+      if (empty($styles) && isset($variables['elements']['block_styles'][$this->pluginId])) {
+        $this->setConfiguration($variables['elements']['block_styles'][$this->pluginId]);
         $styles = $styles = $this->getConfiguration();
       }
     }

--- a/src/Plugin/BlockStyleBase.php
+++ b/src/Plugin/BlockStyleBase.php
@@ -52,16 +52,6 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
   protected $entityTypeManager;
 
   /**
-   * Style settings for the block styles.
-   *
-   * @var array
-   *
-   * @deprecated in 8.x-1.3 and will be removed before 8.x-2.x.
-   *   Instead, you should just use $configuration.
-   */
-  protected $styles;
-
-  /**
    * Construct method for BlockStyleBase.
    *
    * @param array $configuration
@@ -101,8 +91,7 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    // TODO: replace deprecated formElements() with an empty array before 8.x-2.x.
-    return $this->formElements($form, $form_state);
+    return [];
   }
 
   /**
@@ -173,16 +162,6 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
   }
 
   /**
-   * Returns an array of field elements.
-   *
-   * @deprecated in 8.x-1.3 and will be removed before 8.x-2.x.
-   *   Instead, you should just use buildConfigurationForm().
-   */
-  public function formElements($form, FormStateInterface $form_state) {
-    return [];
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function formAlter(array $form, FormStateInterface $form_state) {
@@ -208,7 +187,7 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
   /**
    * {@inheritdoc}
    */
-  public function submitForm($form, FormStateInterface $form_state) {
+  public function submitForm(array $form, FormStateInterface $form_state) {
     // Allow plugins to manipulate the submitForm.
     $subform_state = SubformState::createForSubform($form['third_party_settings']['block_style_plugins'][$this->pluginId], $form, $form_state);
     $this->submitConfigurationForm($form['third_party_settings']['block_style_plugins'][$this->pluginId], $subform_state);
@@ -256,14 +235,10 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
    * {@inheritdoc}
    */
   public function setConfiguration(array $configuration) {
-    // TODO: Replace the deprecated defaultStyles() with defaultConfiguration() before 8.x-2.x.
     $this->configuration = NestedArray::mergeDeep(
-      $this->defaultStyles(),
+      $this->defaultConfiguration(),
       $configuration
     );
-    // Set the deprecated $styles property.
-    // TODO: Remove the deprecated $styles setting before 8.x-2.x.
-    $this->styles = $this->configuration;
   }
 
   /**
@@ -271,38 +246,6 @@ abstract class BlockStyleBase extends PluginBase implements BlockStyleInterface,
    */
   public function calculateDependencies() {
     return [];
-  }
-
-  /**
-   * Gets default style configuration for this plugin.
-   *
-   * @deprecated in 8.x-1.3 and will be removed before 8.x-2.x.
-   *   Instead, you should just use defaultConfiguration().
-   */
-  public function defaultStyles() {
-    return $this->defaultConfiguration();
-  }
-
-  /**
-   * Gets this plugin's style configuration.
-   *
-   * @deprecated in 8.x-1.3 and will be removed before 8.x-2.x.
-   *   Instead, you should just use getConfiguration().
-   */
-  public function getStyles() {
-    @trigger_error('::getStyles() is deprecated in 8.x-1.3 and will be removed before 8.x-2.x. Instead, you should just use getConfiguration(). See https://www.drupal.org/project/block_style_plugins/issues/3016288.', E_USER_DEPRECATED);
-    return $this->getConfiguration();
-  }
-
-  /**
-   * Sets the style configuration for this plugin instance.
-   *
-   * @deprecated in 8.x-1.3 and will be removed before 8.x-2.x.
-   *   Instead, you should just use setConfiguration().
-   */
-  public function setStyles(array $styles) {
-    @trigger_error('::setStyles() is deprecated in 8.x-1.3 and will be removed before 8.x-2.x. Instead, you should just use setConfiguration(). See https://www.drupal.org/project/block_style_plugins/issues/3016288.', E_USER_DEPRECATED);
-    $this->setConfiguration($styles);
   }
 
   /**

--- a/src/Plugin/BlockStyleInterface.php
+++ b/src/Plugin/BlockStyleInterface.php
@@ -73,28 +73,6 @@ interface BlockStyleInterface extends PluginInspectionInterface, ConfigurablePlu
   public function build(array $variables);
 
   /**
-   * Exclude styles from appearing on a block.
-   *
-   * Determine if configuration should be excluded from certain blocks when a
-   * block plugin id or block content type is passed from a plugin.
-   *
-   * @return bool
-   *   Return True if the current block should not get the styles.
-   */
-  public function exclude();
-
-  /**
-   * Only show styles on specific blocks.
-   *
-   * Determine if configuration should be only included on certain blocks when a
-   * block plugin id or block content type is passed from a plugin.
-   *
-   * @return bool
-   *   Return True if the current block should only get the styles.
-   */
-  public function includeOnly();
-
-  /**
    * Add theme suggestions for the block.
    *
    * @param array $suggestions

--- a/src/Plugin/BlockStyleInterface.php
+++ b/src/Plugin/BlockStyleInterface.php
@@ -42,6 +42,16 @@ interface BlockStyleInterface extends PluginInspectionInterface, ConfigurablePlu
   public function formAlter(array $form, FormStateInterface $form_state);
 
   /**
+   * Adds block style specific validation handling for the block form.
+   *
+   * @param array $form
+   *   The form definition array for the full block configuration form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function validateForm(array $form, FormStateInterface $form_state);
+
+  /**
    * Adds block style specific submission handling for the block form.
    *
    * @param array $form
@@ -49,7 +59,7 @@ interface BlockStyleInterface extends PluginInspectionInterface, ConfigurablePlu
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
    */
-  public function submitForm($form, FormStateInterface $form_state);
+  public function submitForm(array $form, FormStateInterface $form_state);
 
   /**
    * Builds and returns the renderable array for this block style plugin.

--- a/tests/src/Functional/CheckboxWithExcludeTest.php
+++ b/tests/src/Functional/CheckboxWithExcludeTest.php
@@ -61,7 +61,7 @@ class CheckboxWithExcludeTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/poweredbytest');
-    $assert->statusCodeEquals(200);
+    $assert->pageTextContains('Block Styles');
 
     // Check that the style options are NOT available.
     $assert->pageTextNotContains('Check this box');
@@ -79,7 +79,6 @@ class CheckboxWithExcludeTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/breadcrumbtest');
-    $assert->statusCodeEquals(200);
 
     // Check that the style options are available.
     $assert->responseContains('Check this box');
@@ -92,7 +91,6 @@ class CheckboxWithExcludeTest extends BrowserTestBase {
 
     // Go to the home page.
     $this->drupalGet('<front>');
-    $assert->statusCodeEquals(200);
 
     // Assert that the block was placed and has the custom class.
     $assert->responseContains('id="block-breadcrumbtest"');

--- a/tests/src/Functional/CustomBlockVisibilityTest.php
+++ b/tests/src/Functional/CustomBlockVisibilityTest.php
@@ -50,7 +50,7 @@ class CustomBlockVisibilityTest extends BlockContentTestBase {
     $this->drupalGet('admin/structure/block/block-content/types');
     $this->drupalGet('admin/structure/block/block-content');
     $this->drupalGet('block/' . $block->id());
-    $assert->statusCodeEquals(200);
+    $assert->pageTextContains('Block description');
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/customblocktest');

--- a/tests/src/Functional/DropdownWithIncludeTest.php
+++ b/tests/src/Functional/DropdownWithIncludeTest.php
@@ -58,7 +58,7 @@ class DropdownWithIncludeTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/breadcrumbtest');
-    $assert->statusCodeEquals(200);
+    $assert->pageTextContains('Block Styles');
 
     // Check that the style options are NOT available.
     $assert->pageTextNotContains('Choose a style from the dropdown');
@@ -73,7 +73,6 @@ class DropdownWithIncludeTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/poweredbytest');
-    $assert->statusCodeEquals(200);
 
     // Check that the style options are available.
     $assert->responseContains('Choose a style from the dropdown');
@@ -87,7 +86,6 @@ class DropdownWithIncludeTest extends BrowserTestBase {
 
     // Go to the home page.
     $this->drupalGet('<front>');
-    $assert->statusCodeEquals(200);
 
     // Assert that the block was placed and has the custom class.
     $assert->responseContains('style-1');

--- a/tests/src/Functional/FormFieldsCreatedWithYaml.php
+++ b/tests/src/Functional/FormFieldsCreatedWithYaml.php
@@ -58,7 +58,7 @@ class FormFieldsCreatedWithYamlTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/breadcrumbtest');
-    $assert->statusCodeEquals(200);
+    $assert->pageTextContains('Block Styles');
 
     // Check that the style options are NOT available.
     $assert->pageTextNotContains('Styles Created by Yaml');
@@ -76,7 +76,6 @@ class FormFieldsCreatedWithYamlTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/poweredbytest');
-    $assert->statusCodeEquals(200);
 
     // Check that the style options are available.
     $assert->responseContains('Title Created by Yaml');
@@ -95,7 +94,6 @@ class FormFieldsCreatedWithYamlTest extends BrowserTestBase {
 
     // Go to the home page.
     $this->drupalGet('<front>');
-    $assert->statusCodeEquals(200);
 
     // Assert that the block was placed and has the custom class.
     $assert->responseContains('id="block-poweredbytest"');

--- a/tests/src/Functional/SimpleClassTest.php
+++ b/tests/src/Functional/SimpleClassTest.php
@@ -60,7 +60,6 @@ class SimpleClassTest extends BrowserTestBase {
 
     // Go to the home page.
     $this->drupalGet('<front>');
-    $assert->statusCodeEquals(200);
 
     // Assert that the block was placed and has the custom class.
     $assert->linkExists('Drupal');

--- a/tests/src/Functional/TemplateSetWithYamlTest.php
+++ b/tests/src/Functional/TemplateSetWithYamlTest.php
@@ -55,7 +55,6 @@ class TemplateSetWithYamlTest extends BrowserTestBase {
 
     // Go to the block instance configuration page.
     $this->drupalGet('admin/structure/block/manage/templatetest');
-    $assert->statusCodeEquals(200);
 
     // Check that the style options are available.
     $assert->responseContains('Template Title');
@@ -69,7 +68,6 @@ class TemplateSetWithYamlTest extends BrowserTestBase {
 
     // Go to the home page.
     $this->drupalGet('<front>');
-    $assert->statusCodeEquals(200);
 
     // Assert that the block was placed and has the template applied.
     $assert->responseContains('This is a custom template');

--- a/tests/src/FunctionalJavascript/LayoutBuilderInlineBlockTest.php
+++ b/tests/src/FunctionalJavascript/LayoutBuilderInlineBlockTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\Tests\block_style_plugins\FunctionalJavascript;
+
+use Drupal\Tests\layout_builder\FunctionalJavascript\InlineBlockTestBase;
+
+/**
+ * Tests that the inline block feature works with styles.
+ *
+ * @group block_style_plugins
+ */
+class InlineBlockTest extends InlineBlockTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'node',
+    'layout_builder',
+    'block_style_plugins',
+    'block_style_plugins_test',
+    'contextual',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $user = $this->drupalCreateUser([
+      'configure any layout',
+      'administer node display',
+      'administer node fields',
+      'access contextual links',
+    ]);
+    $user->save();
+    $this->drupalLogin($user);
+
+    // Enable layout builder.
+    $field_ui_prefix = 'admin/structure/types/manage/bundle_with_section_field';
+    $this->drupalPostForm("$field_ui_prefix/display/default", [
+      'layout[enabled]' => TRUE,
+      'layout[allow_custom]' => TRUE,
+    ], 'Save');
+  }
+
+  /**
+   * Tests that styles are correctly included/excluded from inline blocks.
+   */
+  public function testInlineBlocksVisibility() {
+    $assert = $this->assertSession();
+
+    $this->drupalGet('node/1/layout');
+
+    // Add a basic block with the body field set.
+    $this->addInlineBlockToLayout('Block title', 'The DEFAULT block body');
+
+    // Click the contextual link.
+    $this->clickContextualLink(static::INLINE_BLOCK_LOCATOR, 'Style settings');
+    $assert->assertWaitOnAjaxRequest();
+
+    // There should not be an option for the excluded style.
+    $assert->pageTextContains('Simple Class');
+    $assert->pageTextContains('Dropdown with Include');
+    $assert->pageTextNotContains('Checkbox with Exclude');
+    $assert->pageTextNotContains('Styles Created by Yaml');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/LayoutBuilderTest.php
+++ b/tests/src/FunctionalJavascript/LayoutBuilderTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Drupal\Tests\block_style_plugins\FunctionalJavascript;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\contextual\FunctionalJavascript\ContextualLinkClickTrait;
+
+/**
+ * Layout Builder tests.
+ *
+ * @group block_style_plugins
+ */
+class LayoutBuilderTest extends WebDriverTestBase {
+
+  use ContextualLinkClickTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'node',
+    'layout_builder',
+    'block_style_plugins',
+    'block_style_plugins_test',
+    'contextual',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $user = $this->drupalCreateUser([
+      'configure any layout',
+      'administer node display',
+      'administer node fields',
+      'access contextual links',
+    ]);
+    $user->save();
+    $this->drupalLogin($user);
+    $this->createContentType(['type' => 'bundle_with_section_field']);
+
+    // The Layout Builder UI relies on local tasks.
+    $this->drupalPlaceBlock('local_tasks_block');
+
+    // Enable layout builder.
+    $field_ui_prefix = 'admin/structure/types/manage/bundle_with_section_field';
+    $this->drupalPostForm("$field_ui_prefix/display/default", [
+      'layout[enabled]' => TRUE,
+      'layout[allow_custom]' => TRUE,
+    ], 'Save');
+
+    // Start by creating a node.
+    $node = $this->createNode([
+      'type' => 'bundle_with_section_field',
+      'body' => [
+        [
+          'value' => 'The node body',
+        ],
+      ],
+    ]);
+    $node->save();
+  }
+
+  /**
+   * Tests that styles can be applied via Layout Builder.
+   */
+  public function testLayoutBuilderUi() {
+    $assert = $this->assertSession();
+    $page = $this->getSession()->getPage();
+    $block_css_locator = '.block-system-powered-by-block';
+
+    $this->drupalGet('node/1/layout');
+    $assert->pageTextContains('The node body');
+
+    // Add a new block.
+    $this->clickLink('Add Block');
+    $assert->assertWaitOnAjaxRequest();
+    $this->clickLink('Powered by Drupal');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Add Block');
+
+    // Click the contextual link.
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+
+    // Choose a style to apply.
+    $dropdown = $assert->waitForElementVisible('css', '[name="block_styles"]');
+    $dropdown->selectOption('Simple Class');
+    $page->pressButton('Add Style');
+    $assert->assertWaitOnAjaxRequest();
+
+    // Configure the styles.
+    $page->fillField('settings[simple_class]', 'test-class');
+    $page->pressButton('Add Styles');
+
+    // Check to see if classes were applied.
+    $block_element = $assert->waitForElementVisible('css', $block_css_locator);
+    $block_element->hasClass('test-class');
+
+    // Edit the Style.
+
+    // Click the contextual link to edit.
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+    $assert->assertWaitOnAjaxRequest();
+
+    $this->clickLink('Edit');
+    $assert->assertWaitOnAjaxRequest();
+    $assert->fieldValueEquals('settings[simple_class]', 'test-class');
+    $page->fillField('settings[simple_class]', 'edited-class');
+    $page->pressButton('Update');
+
+    // Save the Layout.
+    $this->clickLink('Save Layout');
+    // Check to see if classes are still applied.
+    $block_element = $assert->waitForElementVisible('css', $block_css_locator);
+    $block_element->hasClass('edited-class');
+
+    // Delete the style.
+
+    $this->drupalGet('node/1/layout');
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+    $assert->assertWaitOnAjaxRequest();
+
+    $this->clickLink('Delete');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Cancel');
+    $assert->assertWaitOnAjaxRequest();
+    $this->clickLink('Delete');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Confirm');
+
+    // Check to see if classes have been removed.
+    $assert->responseNotContains('edited-class');
+    // Save the Layout.
+    $this->clickLink('Save Layout');
+    // Check to see if classes have been removed.
+    $assert->responseContains('The layout override has been saved');
+    $assert->responseNotContains('edited-class');
+  }
+
+  /**
+   * Tests that styles are correctly include/excluded from normal block.
+   */
+  public function testLayoutBuilderBlockVisibility() {
+    $assert = $this->assertSession();
+    $page = $this->getSession()->getPage();
+    $block_css_locator = '.block-system-powered-by-block';
+
+    $this->drupalGet('node/1/layout');
+
+    // Add a new block.
+    $this->clickLink('Add Block');
+    $assert->assertWaitOnAjaxRequest();
+    $this->clickLink('Powered by Drupal');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Add Block');
+
+    // Click the contextual link.
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+    $assert->assertWaitOnAjaxRequest();
+
+    // There should not be an option for the excluded style.
+    $assert->pageTextContains('Styles Created by Yaml');
+    $assert->pageTextContains('Dropdown with Include');
+    $assert->pageTextNotContains('Checkbox with Exclude');
+  }
+
+  /**
+   * Tests that styles are correctly included/excluded from custom blocks.
+   */
+  public function testLayoutBuilderCustomBlockVisibility() {
+    $assert = $this->assertSession();
+    $page = $this->getSession()->getPage();
+
+    // Create the custom block.
+    $block = $this->createBlockContent('Custom Block Test');
+    $block_css_locator = '.block-block-content' . $block->uuid();
+
+    $this->drupalGet('node/1/layout');
+
+    // Add a new block.
+    $this->clickLink('Add Block');
+    $assert->assertWaitOnAjaxRequest();
+    $this->clickLink('Custom Block Test');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Add Block');
+
+    // Click the contextual link.
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+    $assert->assertWaitOnAjaxRequest();
+
+    // There should not be an option for the excluded style.
+    $assert->pageTextContains('Simple Class');
+    $assert->pageTextContains('Dropdown with Include');
+    $assert->pageTextNotContains('Checkbox with Exclude');
+    $assert->pageTextNotContains('Styles Created by Yaml');
+  }
+
+  /**
+   * Tests that a template being set will work with Layout Builder.
+   */
+  public function testLayoutBuilderTemplateSet() {
+    $assert = $this->assertSession();
+    $page = $this->getSession()->getPage();
+    $block_css_locator = '.block-system-powered-by-block';
+
+    $this->drupalGet('node/1/layout');
+
+    // Add a new block.
+    $this->clickLink('Add Block');
+    $assert->assertWaitOnAjaxRequest();
+    $this->clickLink('Powered by Drupal');
+    $assert->assertWaitOnAjaxRequest();
+    $page->pressButton('Add Block');
+
+    // Click the contextual link.
+    $this->clickContextualLink($block_css_locator, 'Style settings');
+
+    // Choose a style to apply.
+    $dropdown = $assert->waitForElementVisible('css', '[name="block_styles"]');
+    $dropdown->selectOption('Template Set by Yaml');
+    $page->pressButton('Add Style');
+    $assert->assertWaitOnAjaxRequest();
+
+    // Configure the styles.
+    $page->fillField('settings[test_field]', 'test-class');
+    $page->pressButton('Add Styles');
+
+    // Assert that the template applied.
+    $assert->responseContains('This is a custom template');
+
+    // Save the Layout.
+    $this->clickLink('Save Layout');
+    // Check to see if the template is still applied.
+    $assert->responseContains('This is a custom template');
+  }
+
+  /**
+   * Creates a custom block.
+   *
+   * @param bool|string $title
+   *   (optional) Title of block. When no value is given uses a random name.
+   *   Defaults to FALSE.
+   * @param string $bundle
+   *   (optional) Bundle name. Defaults to 'basic'.
+   * @param bool $save
+   *   (optional) Whether to save the block. Defaults to TRUE.
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   Created custom block.
+   */
+  protected function createBlockContent($title = FALSE, $bundle = 'basic', $save = TRUE) {
+    $title = $title ?: $this->randomMachineName();
+    $block_content = BlockContent::create([
+      'info' => $title,
+      'type' => $bundle,
+      'langcode' => 'en',
+    ]);
+    if ($block_content && $save === TRUE) {
+      $block_content->save();
+    }
+    return $block_content;
+  }
+
+}

--- a/tests/src/Unit/Plugin/BlockStyleBaseTest.php
+++ b/tests/src/Unit/Plugin/BlockStyleBaseTest.php
@@ -104,8 +104,10 @@ class BlockStyleBaseTest extends UnitTestCase {
     $plugin_definition['provider'] = 'block_style_plugins';
 
     $container = $this->prophesize(ContainerInterface::CLASS);
-    $container->get('entity.repository')->willReturn($this->entityRepository->reveal());
-    $container->get('entity_type.manager')->willReturn($this->entityTypeManager->reveal());
+    $container->get('entity.repository')
+      ->willReturn($this->entityRepository->reveal());
+    $container->get('entity_type.manager')
+      ->willReturn($this->entityTypeManager->reveal());
 
     $instance = MockBlockStyleBase::create(
       $container->reveal(),
@@ -124,7 +126,8 @@ class BlockStyleBaseTest extends UnitTestCase {
   public function testPrepareForm() {
     $block = $this->prophesize(Block::CLASS);
     $block->getPlugin()->willReturn($this->blockPlugin->reveal());
-    $block->getThirdPartySetting('block_style_plugins', 'block_style_plugins')->willReturn(['test_style' => TRUE]);
+    $block->getThirdPartySetting('block_style_plugins', 'block_style_plugins')
+      ->willReturn(['test_style' => TRUE]);
 
     $blockForm = $this->prophesize(BlockForm::CLASS);
     $blockForm->getEntity()->willReturn($block->reveal());
@@ -235,7 +238,8 @@ class BlockStyleBaseTest extends UnitTestCase {
     $storage = $this->prophesize(EntityStorageInterface::CLASS);
     $storage->load(1)->willReturn($block->reveal());
 
-    $this->entityTypeManager->getStorage('block')->willReturn($storage->reveal());
+    $this->entityTypeManager->getStorage('block')
+      ->willReturn($storage->reveal());
 
     // No element ID is passed through the variables.
     $variables = [];
@@ -367,6 +371,11 @@ class BlockStyleBaseTest extends UnitTestCase {
       'No include options are passed' => [NULL, NULL, TRUE],
       'Include basic_block' => ['include', 'basic_block', TRUE],
       'Include only a sample_block' => ['include', 'wrong_block', FALSE],
+      'Include all derivatives of a base_plugin_id' => [
+        'include',
+        'basic_block:*',
+        TRUE,
+      ],
       'No exclude options are passed' => [NULL, NULL, TRUE],
       'Exclude basic_block' => ['exclude', 'basic_block', FALSE],
       'Exclude a block that is not the current one' => [
@@ -374,7 +383,36 @@ class BlockStyleBaseTest extends UnitTestCase {
         'wrong_block',
         TRUE,
       ],
+      'Exclude all derivatives of a base_plugin_id' => [
+        'exclude',
+        'basic_block:*',
+        FALSE,
+      ],
     ];
+  }
+
+  /**
+   * Tests the allowStyles method with Derivatives.
+   *
+   * @see ::allowStyles()
+   */
+  public function testAllowStylesDerivatives() {
+    $plugin_definition = ['exclude' => ['system_menu_block:*']];
+
+    $return = $this->plugin->allowStyles('system_menu_block:main', $plugin_definition);
+    $this->assertFalse($return);
+  }
+
+  /**
+   * Tests the allowStyles method with Layout Builder's Inline Blocks.
+   *
+   * @see ::allowStyles()
+   */
+  public function testAllowStylesInlineBlocks() {
+    $plugin_definition = ['exclude' => ['block_type']];
+
+    $return = $this->plugin->allowStyles('inline_block:block_type', $plugin_definition);
+    $this->assertFalse($return);
   }
 
   /**
@@ -406,6 +444,7 @@ class BlockStyleBaseTest extends UnitTestCase {
         'wrong_block',
         FALSE,
       ],
+      'Exclude all derivatives of a base_plugin_id' => ['basic_block:*', TRUE],
     ];
   }
 
@@ -435,6 +474,7 @@ class BlockStyleBaseTest extends UnitTestCase {
       'No include options are passed' => [NULL, TRUE],
       'Include basic_block' => ['basic_block', TRUE],
       'Include only a sample_block' => ['wrong_block', FALSE],
+      'Include all derivatives of a base_plugin_id' => ['basic_block:*', TRUE],
     ];
   }
 

--- a/tests/src/Unit/Plugin/BlockStyleBaseTest.php
+++ b/tests/src/Unit/Plugin/BlockStyleBaseTest.php
@@ -338,23 +338,56 @@ class BlockStyleBaseTest extends UnitTestCase {
   }
 
   /**
+   * Tests the allowStyles method.
+   *
+   * @see ::allowStyles()
+   *
+   * @dataProvider allowStylesProvider
+   */
+  public function testAllowStyles($type, $plugin, $expected) {
+    $plugin_definition = [];
+
+    if ($plugin) {
+      $plugin_definition = [$type => [$plugin]];
+    }
+
+    $return = $this->plugin->allowStyles('basic_block', $plugin_definition);
+    $this->assertEquals($expected, $return);
+  }
+
+  /**
+   * Provider for testAllowStyles()
+   */
+  public function allowStylesProvider() {
+    return [
+      'No include options are passed' => [NULL, NULL, TRUE],
+      'Include basic_block' => ['include', 'basic_block', TRUE],
+      'Include only a sample_block' => ['include', 'wrong_block', FALSE],
+      'No exclude options are passed' => [NULL, NULL, TRUE],
+      'Exclude basic_block' => ['exclude', 'basic_block', FALSE],
+      'Exclude a block that is not the current one' => [
+        'exclude',
+        'wrong_block',
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
    * Tests the exclude method.
    *
    * @see ::exclude()
    *
    * @dataProvider excludeProvider
    */
-  public function testExclude($plugin, $bundle, $expected) {
-    // Stub the blockPlugin.
-    $this->setProtectedProperty('blockPlugin', $this->blockPlugin->reveal());
+  public function testExclude($plugin_id, $expected) {
+    $plugin_definition = [];
 
-    if ($plugin) {
-      $this->setProtectedProperty('pluginDefinition', ['exclude' => [$plugin]]);
+    if ($plugin_id) {
+      $plugin_definition = ['exclude' => [$plugin_id]];
     }
-    if ($bundle) {
-      $this->setProtectedProperty('blockContentBundle', $bundle);
-    }
-    $return = $this->plugin->exclude();
+
+    $return = $this->plugin->exclude('basic_block', $plugin_definition);
     $this->assertEquals($expected, $return);
   }
 
@@ -363,21 +396,10 @@ class BlockStyleBaseTest extends UnitTestCase {
    */
   public function excludeProvider() {
     return [
-      'No exclude options are passed' => [FALSE, NULL, FALSE],
-      'Exclude basic_block' => ['basic_block', NULL, TRUE],
+      'No exclude options are passed' => [FALSE, FALSE],
+      'Exclude basic_block' => ['basic_block', TRUE],
       'Exclude a block that is not the current one' => [
         'wrong_block',
-        NULL,
-        FALSE,
-      ],
-      'Exclude a custom content block' => [
-        'custom_block',
-        'custom_block',
-        TRUE,
-      ],
-      'Exclude a custom content block that is not the current block' => [
-        'wrong_custom_block',
-        'custom_block',
         FALSE,
       ],
     ];
@@ -390,17 +412,14 @@ class BlockStyleBaseTest extends UnitTestCase {
    *
    * @dataProvider includeOnlyProvider
    */
-  public function testIncludeOnly($plugin, $bundle, $expected) {
-    // Stub the blockPlugin.
-    $this->setProtectedProperty('blockPlugin', $this->blockPlugin->reveal());
+  public function testIncludeOnly($plugin_id, $expected) {
+    $plugin_definition = [];
 
-    if ($plugin) {
-      $this->setProtectedProperty('pluginDefinition', ['include' => [$plugin]]);
+    if ($plugin_id) {
+      $plugin_definition = ['include' => [$plugin_id]];
     }
-    if ($bundle) {
-      $this->setProtectedProperty('blockContentBundle', $bundle);
-    }
-    $return = $this->plugin->includeOnly();
+
+    $return = $this->plugin->includeOnly('basic_block', $plugin_definition);
     $this->assertEquals($expected, $return);
   }
 
@@ -409,19 +428,9 @@ class BlockStyleBaseTest extends UnitTestCase {
    */
   public function includeOnlyProvider() {
     return [
-      'No include options are passed' => [NULL, NULL, TRUE],
-      'Include basic_block' => ['basic_block', NULL, TRUE],
-      'Include only a sample_block' => ['wrong_block', NULL, FALSE],
-      'Include a custom content block' => [
-        'custom_block',
-        'custom_block',
-        TRUE,
-      ],
-      'Include a custom content block which is not the current one' => [
-        'wrong_custom_block',
-        'custom_block',
-        FALSE,
-      ],
+      'No include options are passed' => [NULL, TRUE],
+      'Include basic_block' => ['basic_block', TRUE],
+      'Include only a sample_block' => ['wrong_block', FALSE],
     ];
   }
 

--- a/tests/src/Unit/Plugin/BlockStyleBaseTest.php
+++ b/tests/src/Unit/Plugin/BlockStyleBaseTest.php
@@ -257,8 +257,10 @@ class BlockStyleBaseTest extends UnitTestCase {
     $variables = ['elements' => ['#id' => 1]];
     $expected = [
       'elements' => ['#id' => 1],
-      'block_styles' => [
-        'block_style_plugins' => ['class1', 'class2'],
+      'configuration' => [
+        'block_styles' => [
+          'block_style_plugins' => ['class1', 'class2'],
+        ],
       ],
       'attributes' => [
         'class' => [
@@ -277,8 +279,10 @@ class BlockStyleBaseTest extends UnitTestCase {
     $variables = ['elements' => ['#id' => 1]];
     $expected = [
       'elements' => ['#id' => 1],
-      'block_styles' => [
-        'block_style_plugins' => ['class1', 1, 'class2', 0],
+      'configuration' => [
+        'block_styles' => [
+          'block_style_plugins' => ['class1', 1, 'class2', 0],
+        ],
       ],
       'attributes' => [
         'class' => [


### PR DESCRIPTION
This adds support for the new Layout Builder in Drupal Core.

To test this, clone this branch and add it into a Drupal 8 site with Layout Builder enabled. Then enable the Block Style Plugins module. Nothing will happen until a plugin is declared. This can be done by dropping a `*.blockstyle.yml` file into a theme or module (add module or theme name to the start of the file), and then add the following to it.

```yml
custom_class:
  label: 'Add a custom class'
  form:
    'test_field':
      '#type': 'textfield'
      '#title': 'Add a custom class to this block'
      '#description': 'Do not add the "period" to the start of the class'
```

Make sure that you have set a content type to use the Layout Builder `/admin/structure/types/manage/page/display`

A block placed in the Layout Builder will now have a new "Style settings" contextual link you can select when editing a layout.
![screen shot 2018-12-03 at 8 01 55 pm](https://user-images.githubusercontent.com/6034878/49418323-6e8f9b80-f736-11e8-94eb-b093bdcfadbf.png)

